### PR TITLE
Qualify `freshclam` exec

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
 2013-09-14 Release 0.0.1
 - Initial release
+
+2014-03-12 Release 0.0.2
+- Qualified `exec` type in `manifests/run_freshclam.pp`

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'gdsoperations-clamav'
-version       '0.0.1'
+version       '0.0.2'
 source        'UNKNOWN'
 author        'gdsoperations'
 license       'MIT'

--- a/manifests/run_freshclam.pp
+++ b/manifests/run_freshclam.pp
@@ -6,7 +6,7 @@
 # should have run by the time Puppet next attempts to start clamav-daemon.
 #
 class clamav::run_freshclam {
-  exec { 'freshclam --quiet':
+  exec { '/usr/bin/freshclam --quiet':
     refreshonly => true,
   }
 }


### PR DESCRIPTION
This pull request qualifies `freshclam --quiet` in order to ensure it runs without
error. Previously, the command would fail to run as the exec was unqualified,
and Puppet could not find the executable.

Puppet refuses to trust that the $PATH of the shell from which a Puppet run is
started is correct. It therefore demands qualified `exec` types.
