### PR TITLE
Increase exec timeout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,3 +3,4 @@
 
 2014-03-12 Release 0.0.2
 - Qualified `exec` type in `manifests/run_freshclam.pp`
+- Increased `timeout` parameter on `exec` type in `manifests/run_freshclam.pp`

--- a/manifests/run_freshclam.pp
+++ b/manifests/run_freshclam.pp
@@ -7,6 +7,7 @@
 #
 class clamav::run_freshclam {
   exec { '/usr/bin/freshclam --quiet':
+    timeout     => 480,
     refreshonly => true,
   }
 }


### PR DESCRIPTION
The default value of the timeout parameter used in the exec type in Puppet is
300secs. freshclam takes longer than 300secs to complete at times. If this
happens when a box is brought up, the provisioning may fail. Even though
freshclam will re-run after a while once the box has booted, it is far better to
ensure that we get a successful output from freshclam during provision, rather
than an error relating to it timing out.

This pull request increases the timeout value from 300s to 600s.
