### PR TITLE
Manage clamd process with daemon

### DIFF
--- a/files/etc/clamd.conf
+++ b/files/etc/clamd.conf
@@ -4,6 +4,7 @@ LogTime yes
 LogSyslog yes
 LogVerbose yes
 ExtendedDetectionInfo yes
+Foreground yes
 TCPSocket 3310
 TCPAddr 127.0.0.1
 MaxConnectionQueueLength 50

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -2,7 +2,7 @@
 #
 # install clamav packages
 class clamav::package {
-  package { ['clamav', 'clamav-freshclam', 'clamav-daemon']:
+  package { ['clamav', 'clamav-freshclam', 'clamav-daemon', 'daemon']:
     ensure  => 'latest',
   }
 


### PR DESCRIPTION
The clamd process can crash quite often. This managed the process with
daemon to restart it automatically.

See:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=250008
